### PR TITLE
Android Studio Arctic Fox | 2020.3.1 Canary 15 업데이트 이후 에러 발생 #2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.0-alpha14"
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha15'
         classpath lib.kotlin.plugin
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 19 15:34:02 KST 2021
+#Mon May 10 01:38:47 KST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,5 +1,5 @@
 ext {
-    kotlinVersion = '1.4.32'
+    kotlinVersion = '1.4.30'
     composeVersion = '1.0.0-beta01'
     koinVersion = '2.2.0'
     rxjava2Version = "2.0.1"


### PR DESCRIPTION
- gradle:7.0.0-alpha14 버전에서 alpha15버전으로 변경
- kotlinVersion 1.4.32에서 1.4.30으로 변경
- gradle 업데이트 및 kotlin version 수정