### PR TITLE
Switch 디자인 커스텀 #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/misc.xml
 .DS_Store
 /build
 /captures

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,6 +3,12 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="../../../../../layout/compose-model-1619847247379.xml" value="0.28888888888888886" />
+        <entry key="../../../../../layout/compose-model-1619847450129.xml" value="1.0" />
+        <entry key="../../../../../layout/compose-model-1619847934581.xml" value="0.28888888888888886" />
+        <entry key="../../../../../layout/compose-model-1619848742647.xml" value="0.25" />
+        <entry key="../../../../../layout/compose-model-1619855757733.xml" value="0.25" />
+        <entry key="../../../../../layout/compose-model-1619857482938.xml" value="0.3472222222222222" />
         <entry key="../../../../layout/compose-model-1619012044353.xml" value="0.1" />
         <entry key="../../../../layout/compose-model-1619012897588.xml" value="0.5194444444444445" />
         <entry key="../../../../layout/compose-model-1619242634699.xml" value="0.2212962962962963" />
@@ -17,9 +23,18 @@
         <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/bg_default_switch_track.xml" value="0.30185185185185187" />
         <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/bg_default_switch_track_checked.xml" value="0.30185185185185187" />
         <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/bg_default_switch_track_normal.xml" value="0.30185185185185187" />
+        <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/custom_switch_compat_thumb.xml" value="0.67" />
+        <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/custom_switch_compat_track_off.xml" value="0.4473958333333333" />
+        <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/custom_switch_compat_track_on.xml" value="0.4473958333333333" />
+        <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/ic_alram.xml" value="0.29322916666666665" />
+        <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/ic_mypage.xml" value="0.29322916666666665" />
+        <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/ic_ranking.xml" value="0.29322916666666665" />
         <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/drawable/switch_track_selector.xml" value="0.30185185185185187" />
         <entry key="..\:/Users/Jackson/AndroidStudioProjects/LinkZupZup/app/src/main/res/layout/switch_compat.xml" value="0.22" />
+        <entry key="app/src/main/res/drawable/ic_alram.xml" value="0.3472222222222222" />
+        <entry key="app/src/main/res/drawable/ic_black_alarm.xml" value="0.28888888888888886" />
         <entry key="app/src/main/res/drawable/ic_black_close.xml" value="0.29814814814814816" />
+        <entry key="app/src/main/res/drawable/ic_gray_more.xml" value="0.28888888888888886" />
       </map>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-android-extensions'
 }
 
 android {

--- a/app/src/main/java/com/depromeet/linkzupzup/extensions/extensions.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/extensions/extensions.kt
@@ -1,5 +1,9 @@
 package com.depromeet.linkzupzup.extensions
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import com.depromeet.linkzupzup.base.BaseView
 import com.depromeet.linkzupzup.component.SSLHelper
@@ -26,6 +30,9 @@ fun <T> Single<T>.schedulers(subscribeOnScheduler: Scheduler = Schedulers.io(),
 fun <T> Single<T>.subSimple(onSuccess: Consumer<in T>?, baseView: BaseView<*>): Disposable {
     return subscribe(onSuccess, { baseView.defaultThrowable(it) })
 }
+
+@Composable
+fun <T> T.mutableStateValue(): MutableState<T> = remember { mutableStateOf(this) }
 
 /**
  * 참고 : https://meetup.toast.com/posts/130

--- a/app/src/main/java/com/depromeet/linkzupzup/view/alarm/ui/AlarmDetailUI.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/view/alarm/ui/AlarmDetailUI.kt
@@ -5,10 +5,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -25,12 +26,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.depromeet.linkzupzup.R
 import com.depromeet.linkzupzup.base.BaseView
+import com.depromeet.linkzupzup.extensions.mutableStateValue
 import com.depromeet.linkzupzup.extensions.timeBaseStr
 import com.depromeet.linkzupzup.extensions.timeStr
 import com.depromeet.linkzupzup.presenter.AlarmDetailViewModel
 import com.depromeet.linkzupzup.presenter.model.WeeklyAlarm
 import com.depromeet.linkzupzup.ui.theme.LinkZupZupTheme
 import com.depromeet.linkzupzup.utils.DLog
+import com.depromeet.linkzupzup.view.custom.CustomSwitchCompat
 import java.util.*
 
 class AlarmDetailUI: BaseView<AlarmDetailViewModel>() {
@@ -88,10 +91,9 @@ fun BodyContent(alarms: ArrayList<WeeklyAlarm>, alarmClickListener: ()->Unit) {
                     .fillMaxWidth()
                     .weight(1f)) {
 
-                items(alarmList.value) { alarm ->
-                    WeeklyAlarmCard(alarm)
+                itemsIndexed(items= alarmList.value) { index, alarm ->
+                    WeeklyAlarmCard(alarmList, index)
                 }
-
             }
 
             
@@ -138,105 +140,115 @@ fun TopHeaderCard() {
 }
 
 @Composable
-fun WeeklyAlarmCard(alarm: WeeklyAlarm) {
+fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
+    list.value[index].let { alarm ->
 
-    Card(shape = RoundedCornerShape(4.dp),
-        backgroundColor = Color.White,
-        elevation = 2.dp,
-        modifier = Modifier.clickable {
+        // 알람 설정 유무
+        val enableAlarm: MutableState<Boolean> = alarm.isEnableAlarm().mutableStateValue()
+        alarm.enableAlarm = if (enableAlarm.value) 1 else 0
 
-        }) {
+        Card(shape = RoundedCornerShape(4.dp),
+            backgroundColor = Color.White,
+            elevation = 2.dp,
+            modifier = Modifier.clickable {
 
-        Box(Modifier.fillMaxWidth()
-            .height(110.dp)) {
+            }) {
 
-            Column(modifier = Modifier
-                .fillMaxWidth()
-                .height(110.dp)
-                .padding(horizontal = 24.dp, vertical = 19.dp)) {
-
-                Row(verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(40.dp)) {
-
-                    Image(painter = painterResource(id = R.drawable.ic_sun_img),
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp))
-
-                    Spacer(Modifier.width(4.dp))
-
-                    Text(alarm.dateTime.timeBaseStr(),
-                        style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 12.sp, lineHeight = 16.8.sp, color = Color(0xFF292A2B)))
-
-                    Spacer(Modifier.width(8.dp))
-
-                    Text(alarm.dateTime.timeStr(),
-                        style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), textAlign = TextAlign.Start, fontSize = 32.sp, lineHeight = 10.sp, color = Color(0xFF292A2B)),
-                        modifier = Modifier.absoluteOffset(y = -(5).dp))
-
-                    Spacer(Modifier.weight(1f))
-
-                    Switch(checked = alarm.isEnableAlarm(),
-                        onCheckedChange = { checked ->
-                            alarm.enableAlarm = if (checked) 1 else 0
-                            DLog.e("Jackso", "state: $checked")
-                        }, colors = SwitchDefaults.colors(
-                            checkedThumbColor = Color(0xFFFFFFFF),
-                            checkedTrackColor = Color(0xFF4076F6),
-                            uncheckedThumbColor = Color(0xFFFFFFFF),
-                            uncheckedTrackColor = Color(0xFFCED3D6)
-                        ),
-                        enabled = true,
-                        modifier = Modifier
-                            .width(46.dp)
-                            .height(24.dp))
-
-                }
-
-                Spacer(Modifier.height(10.dp))
-
-                Row(modifier = Modifier
+            Box(
+                Modifier
                     .fillMaxWidth()
-                    .height(22.dp)) {
+                    .height(110.dp)) {
 
-                    Card(shape = RoundedCornerShape(2.dp),
-                        backgroundColor = Color(0xFFEAEBEF)) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Text(alarm.weekDayStr(),
-                                style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 10.sp, lineHeight = 14.sp, color = Color(0xFF000000)),
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.height(22.dp)
-                                    .padding(horizontal = 8.dp, vertical = 4.dp))
-                        }
+                Column(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(110.dp)
+                    .padding(horizontal = 24.dp, vertical = 19.dp)) {
+
+                    Row(verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(40.dp)) {
+
+                        Image(painter = painterResource(id = R.drawable.ic_sun_img),
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp))
+
+                        Spacer(Modifier.width(4.dp))
+
+                        Text(alarm.dateTime.timeBaseStr(),
+                            style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 12.sp, lineHeight = 16.8.sp, color = Color(0xFF292A2B)))
+
+                        Spacer(Modifier.width(8.dp))
+
+                        Text(alarm.dateTime.timeStr(),
+                            style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), textAlign = TextAlign.Start, fontSize = 32.sp, lineHeight = 10.sp, color = Color(0xFF292A2B)),
+                            modifier = Modifier.absoluteOffset(y = -(5).dp))
+
                     }
 
-                    if (alarm.isHolidayUse == 1) {
-                        Spacer(Modifier.width(8.dp))
+                    Spacer(Modifier.height(10.dp))
+
+                    Row(modifier = Modifier
+                        .fillMaxWidth()
+                        .height(22.dp)) {
+
                         Card(shape = RoundedCornerShape(2.dp),
-                            backgroundColor = Color(0xFFFFEFF0)) {
+                            backgroundColor = Color(0xFFEAEBEF)) {
                             Box(contentAlignment = Alignment.Center) {
-                                Text("#공휴일에 울려요",
-                                    style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 10.sp, lineHeight = 14.sp, color = Color(0xFFF24147)),
+                                Text(alarm.weekDayStr(),
+                                    style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 10.sp, lineHeight = 14.sp, color = Color(0xFF000000)),
                                     textAlign = TextAlign.Center,
-                                    modifier = Modifier.height(22.dp)
+                                    modifier = Modifier
+                                        .height(22.dp)
                                         .padding(horizontal = 8.dp, vertical = 4.dp))
+                            }
+                        }
+
+                        if (alarm.isHolidayUse == 1) {
+                            Spacer(Modifier.width(8.dp))
+                            Card(shape = RoundedCornerShape(2.dp),
+                                backgroundColor = Color(0xFFFFEFF0)) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    Text("#공휴일에 울려요",
+                                        style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 10.sp, lineHeight = 14.sp, color = Color(0xFFF24147)),
+                                        textAlign = TextAlign.Center,
+                                        modifier = Modifier
+                                            .height(22.dp)
+                                            .padding(horizontal = 8.dp, vertical = 4.dp))
+                                }
                             }
                         }
                     }
                 }
+
+                /**
+                 * 비활성화 블러
+                 */
+                if (!enableAlarm.value) Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight()
+                        .background(color = Color(0xCCFFFFFF))) {}
+
+                /**
+                 * 카드가 비활성화 될경우 블러 위에 스위치가 표현되어야 하므로 상위 레이어에 배치.
+                 */
+                Column(horizontalAlignment = Alignment.End,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(110.dp)
+                        .padding(top = 29.dp, end = 24.dp)) {
+
+                    CustomSwitchCompat(switchCompatInstance = { it.isChecked = enableAlarm.value },
+                        checkedOnChangeListener = { view, isChecked ->
+                            enableAlarm.value = isChecked
+                        })
+                }
+
             }
-
-            /**
-             * 비활성화 블러
-             */
-            if (!alarm.isEnableAlarm()) Row(Modifier.fillMaxWidth()
-                .fillMaxHeight()
-                .background(color = Color(0xCCFFFFFF))) { }
-
         }
-    }
 
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/depromeet/linkzupzup/view/custom/CustomUI.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/view/custom/CustomUI.kt
@@ -1,0 +1,46 @@
+package com.depromeet.linkzupzup.view.custom
+
+import android.widget.CompoundButton
+import androidx.annotation.DrawableRes
+import androidx.appcompat.widget.SwitchCompat
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import com.depromeet.linkzupzup.R
+
+/**
+ * Modifier.width(46.dp) -> Thumb 여백 2dp로 인해 width를 딱맞게 지정할 경우, SwitchCompat이 짤리는 현상발생
+ * height만 지정해서 사용해야 될것 같습니다.
+ *
+ * switchCompatInstance callback : SwitchCompat Instance를 참조하기 위한 용도이며,
+ * 생성 시, SwitchCompat Instance를 반환합니다.
+ *
+ * updateCallback callback : View가 확장될 때 호출되는 update 콜백, 사용할 필요가 없을걸로 예상됩니다.
+ */
+@Composable
+fun CustomSwitchCompat(modifier: Modifier = Modifier.height(24.dp),
+                       @DrawableRes thumbDrawableRes: Int = R.drawable.custom_switch_compat_thumb,
+                       @DrawableRes trackDrawableRes: Int = R.drawable.custom_switch_compat_track,
+                       switchCompatInstance: (SwitchCompat)->Unit = {},
+                       updateCallback: (SwitchCompat)->Unit = {},
+                       checkedOnChangeListener: CompoundButton.OnCheckedChangeListener? = null) {
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+
+            SwitchCompat(ctx).apply {
+                thumbDrawable = ContextCompat.getDrawable(context, thumbDrawableRes)
+                trackDrawable = ContextCompat.getDrawable(context, trackDrawableRes)
+                checkedOnChangeListener?.let { listener -> setOnCheckedChangeListener(listener) }
+                switchCompatInstance.invoke(this)
+            }
+        },
+        update = { view ->
+            updateCallback.invoke(view)
+        }
+    )
+
+}

--- a/app/src/main/res/drawable/custom_switch_compat_thumb.xml
+++ b/app/src/main/res/drawable/custom_switch_compat_thumb.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="2dp"
+        android:left="2dp"
+        android:right="2dp"
+        android:top="2dp">ㅣ
+
+        <selector>
+            <item android:state_checked="true">
+                <shape android:shape="oval">
+                    <corners android:radius="10dp" />
+                    <size
+                        android:width="20dp"
+                        android:height="20dp" />
+                    <solid android:color="#ffffff" />
+                    <stroke android:width="2dp"
+                        android:color="@android:color/transparent" />
+                </shape>
+            </item>
+
+            <item android:state_checked="false">
+                <shape android:shape="oval">
+                    <corners android:radius="10dp" />
+                    <size
+                        android:width="20dp"
+                        android:height="20dp" />
+                    <solid android:color="#ffffff" />
+                    <stroke android:width="2dp"
+                        android:color="@android:color/transparent" />
+                </shape>
+            </item>
+        </selector>
+
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/custom_switch_compat_track.xml
+++ b/app/src/main/res/drawable/custom_switch_compat_track.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/custom_switch_compat_track_on" android:state_checked="true" />
+    <item android:drawable="@drawable/custom_switch_compat_track_off" android:state_checked="false" />
+</selector>

--- a/app/src/main/res/drawable/custom_switch_compat_track_off.xml
+++ b/app/src/main/res/drawable/custom_switch_compat_track_off.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <corners android:radius="12dp" />
+
+    <size
+        android:width="46dp"
+        android:height="24dp" />
+
+    <solid android:color="#CED3D6" />
+
+</shape>

--- a/app/src/main/res/drawable/custom_switch_compat_track_on.xml
+++ b/app/src/main/res/drawable/custom_switch_compat_track_on.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <corners android:radius="12dp" />
+
+    <size
+        android:width="46dp"
+        android:height="24dp" />
+
+    <solid android:color="#4076F6" />
+
+</shape>


### PR DESCRIPTION
- SwitchCompat 커스텀
- Compose AndroidView로 SwitchCompat을 Compose에서 사용가능하도록 작업진행
- 확장메서드 mutableStateValue 추가
  "( remember { mutableStateOf( ? ) }" -> 매번 쓰기 귀찮아서 아래와 같이 단축
  ?.mutableStateValue()
- kotlin-android-extensions plugins 추가
  ( @Parcelize 어노테이션 등 기타 확장 기능 사용하기 위한 용도 )