### PR TITLE
Alarm detail UI 9

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:theme="@style/Theme.LinkZupZup">
 
         <activity
-            android:name=".view.main.MainActivity"
+            android:name=".view.alarm.AlarmDetailActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.LinkZupZup.NoActionBar">
@@ -29,7 +29,7 @@
         <activity android:name=".view.scrap.ScrapDetailActivity" />
         <activity android:name=".view.mypage.MyPageActivity" />
         <activity android:name=".view.mydonut.MyDonutActivity" />
-        <activity android:name=".view.alarm.AlarmDetailActivity" />
+        <activity android:name=".view.main.MainActivity" />
         <activity android:name=".view.webView.WebViewActivity"/>
 
         <receiver android:name=".receiver.AlarmReceiver">

--- a/app/src/main/java/com/depromeet/linkzupzup/architecture/dataLayer/AlarmDataSource.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/architecture/dataLayer/AlarmDataSource.kt
@@ -2,6 +2,7 @@ package com.depromeet.linkzupzup.architecture.dataLayer
 
 import com.depromeet.linkzupzup.ParamsInfo
 import com.depromeet.linkzupzup.architecture.dataLayer.api.AlarmAPIService
+import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseArrayEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmRegistEntity
@@ -12,7 +13,7 @@ class AlarmDataSource(private val api: AlarmAPIService) {
     /**
      * 어플 알람 리스트 조회
      */
-    fun getAlarmList(): Observable<ResponseEntity<AlarmEntity>>
+    fun getAlarmList(): Observable<ResponseArrayEntity<AlarmEntity>>
         = api.getAlarmList()
 
     /**

--- a/app/src/main/java/com/depromeet/linkzupzup/architecture/dataLayer/api/AlarmAPIService.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/architecture/dataLayer/api/AlarmAPIService.kt
@@ -1,6 +1,7 @@
 package com.depromeet.linkzupzup.architecture.dataLayer.api
 
 import com.depromeet.linkzupzup.ApiUrl
+import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseArrayEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmRegistEntity
@@ -13,7 +14,7 @@ interface AlarmAPIService {
      * 어플 알람 리스트 조회
      */
     @GET(ApiUrl.ALARM_LIST)
-    fun getAlarmList(): Observable<ResponseEntity<AlarmEntity>>
+    fun getAlarmList(): Observable<ResponseArrayEntity<AlarmEntity>>
 
     /**
      * 어플 알람 등록

--- a/app/src/main/java/com/depromeet/linkzupzup/architecture/dataLayer/repositories/AlarmRepository.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/architecture/dataLayer/repositories/AlarmRepository.kt
@@ -1,5 +1,6 @@
 package com.depromeet.linkzupzup.architecture.dataLayer.repositories
 
+import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseArrayEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmRegistEntity
@@ -15,7 +16,7 @@ interface AlarmRepository {
     /**
      * 어플 알람 리스트 조회
      */
-    fun getAlarmList(): Observable<ResponseEntity<AlarmEntity>>
+    fun getAlarmList(): Observable<ResponseArrayEntity<AlarmEntity>>
 
     /**
      * 어플 알람 등록

--- a/app/src/main/java/com/depromeet/linkzupzup/architecture/dataLayer/repositories/AlarmRepositoryImpl.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/architecture/dataLayer/repositories/AlarmRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.depromeet.linkzupzup.architecture.dataLayer.repositories
 
 import com.depromeet.linkzupzup.architecture.dataLayer.AlarmDataSource
+import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseArrayEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmRegistEntity
@@ -22,7 +23,7 @@ class AlarmRepositoryImpl(private val alarmDataSource: AlarmDataSource): AlarmRe
     /**
      * 어플 알람 리스트 조회
      */
-    override fun getAlarmList(): Observable<ResponseEntity<AlarmEntity>>
+    override fun getAlarmList(): Observable<ResponseArrayEntity<AlarmEntity>>
         = alarmDataSource.getAlarmList()
 
     /**

--- a/app/src/main/java/com/depromeet/linkzupzup/architecture/domainLayer/AlarmUseCases.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/architecture/domainLayer/AlarmUseCases.kt
@@ -1,6 +1,7 @@
 package com.depromeet.linkzupzup.architecture.domainLayer
 
 import com.depromeet.linkzupzup.architecture.dataLayer.repositories.AlarmRepositoryImpl
+import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseArrayEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmRegistEntity
@@ -23,7 +24,7 @@ class AlarmUseCases(private val alarmRepositoryImpl: AlarmRepositoryImpl) {
     /**
      * 어플 알람 리스트 조회
      */
-    fun getAlarmList(): Observable<ResponseEntity<AlarmEntity>>
+    fun getAlarmList(): Observable<ResponseArrayEntity<AlarmEntity>>
         = alarmRepositoryImpl.getAlarmList()
 
     /**

--- a/app/src/main/java/com/depromeet/linkzupzup/architecture/domainLayer/entities/DefaultResponseEntity.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/architecture/domainLayer/entities/DefaultResponseEntity.kt
@@ -1,0 +1,6 @@
+package com.depromeet.linkzupzup.architecture.domainLayer.entities
+
+interface DefaultResponseEntity {
+    var status: String
+    var comment: String
+}

--- a/app/src/main/java/com/depromeet/linkzupzup/architecture/domainLayer/entities/ResponseArrayEntity.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/architecture/domainLayer/entities/ResponseArrayEntity.kt
@@ -2,7 +2,7 @@ package com.depromeet.linkzupzup.architecture.domainLayer.entities
 
 import com.google.gson.annotations.SerializedName
 
-class ResponseEntity<T>(
+class ResponseArrayEntity<T> (
 
     @SerializedName("status")
     override var status: String = "",
@@ -11,4 +11,4 @@ class ResponseEntity<T>(
     override var comment: String = "",
 
     @SerializedName("data")
-    var data: T? = null): DefaultResponseEntity
+    var data: ArrayList<T> = arrayListOf()): DefaultResponseEntity

--- a/app/src/main/java/com/depromeet/linkzupzup/architecture/presenterLayer/AlarmDetailViewModel.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/architecture/presenterLayer/AlarmDetailViewModel.kt
@@ -1,6 +1,7 @@
 package com.depromeet.linkzupzup.architecture.presenterLayer
 
 import com.depromeet.linkzupzup.architecture.domainLayer.AlarmUseCases
+import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseArrayEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmEntity
 import com.depromeet.linkzupzup.architecture.domainLayer.entities.api.AlarmRegistEntity
@@ -21,7 +22,7 @@ class AlarmDetailViewModel(private val alarmUseCases: AlarmUseCases): BaseViewMo
     /**
      * 어플 알람 리스트 조회
      */
-    fun getAlarmList(callback: ((ResponseEntity<AlarmEntity>)->Unit)? = null) {
+    fun getAlarmList(callback: ((ResponseArrayEntity<AlarmEntity>)->Unit)? = null) {
         progressStatus(true)
         addDisposable(alarmUseCases.getAlarmList()
             .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/depromeet/linkzupzup/di/NetworkModule.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/di/NetworkModule.kt
@@ -11,6 +11,9 @@ import com.google.gson.GsonBuilder
 import com.depromeet.linkzupzup.ApiUrl
 import com.depromeet.linkzupzup.AppConst.AUTHHORIZATION_KEY
 import com.depromeet.linkzupzup.AppConst.USER_ID_KEY
+import com.depromeet.linkzupzup.architecture.domainLayer.entities.DefaultResponseEntity
+import com.depromeet.linkzupzup.architecture.domainLayer.entities.ResponseEntity
+import com.google.gson.Gson
 import com.jakewharton.retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import okhttp3.Cache
 import okhttp3.Interceptor
@@ -62,5 +65,27 @@ val networkModule = module {
             }.build())
         }
     }
+
+//    single {
+//        Interceptor {  chain ->
+//            val newRequest = chain.request().newBuilder().build()
+//            chain.proceed(newRequest).also { response ->
+//
+//                response.body()?.let { responseBody ->
+//                    val buffer = responseBody.source()
+//                        .buffer()
+//                        .clone()
+//
+//                    val responseStr = buffer.readString(Charsets.UTF_8)
+//                    Gson().fromJson(responseStr, DefaultResponseEntity::class.java).let {
+//                        when (it.status) {
+//                            // 상태값이 다른 API들에서 중복되어 사용되고 있어 의논이 필요
+//
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
 
 }

--- a/app/src/main/java/com/depromeet/linkzupzup/ui/theme/Shape.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/ui/theme/Shape.kt
@@ -17,4 +17,6 @@ val BottomSheetShape = RoundedCornerShape(
     bottomStart = 0.dp
 )
 
+// tag
 val Round8RectShape = RoundedCornerShape(8.dp)
+val Round2RectShape = RoundedCornerShape(2.dp)

--- a/app/src/main/java/com/depromeet/linkzupzup/view/alarm/AlarmDetailActivity.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/view/alarm/AlarmDetailActivity.kt
@@ -3,7 +3,9 @@ package com.depromeet.linkzupzup.view.alarm
 import android.os.Bundle
 import com.depromeet.linkzupzup.base.BaseActivity
 import com.depromeet.linkzupzup.architecture.presenterLayer.AlarmDetailViewModel
+import com.depromeet.linkzupzup.utils.DLog
 import com.depromeet.linkzupzup.view.alarm.ui.AlarmDetailUI
+import com.google.gson.Gson
 import org.koin.androidx.viewmodel.ext.android.getViewModel
 
 class AlarmDetailActivity : BaseActivity<AlarmDetailUI, AlarmDetailViewModel>() {
@@ -13,6 +15,11 @@ class AlarmDetailActivity : BaseActivity<AlarmDetailUI, AlarmDetailViewModel>() 
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(viewModel) {
+            getAlarmList {
+                DLog.e("AlarmDetail", "${Gson().toJson(it)}")
+            }
+        }
     }
 
 }

--- a/app/src/main/java/com/depromeet/linkzupzup/view/alarm/ui/AlarmDetailUI.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/view/alarm/ui/AlarmDetailUI.kt
@@ -1,10 +1,8 @@
 package com.depromeet.linkzupzup.view.alarm.ui
 
 import android.widget.Toast
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.appcompat.widget.SwitchCompat
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -27,14 +25,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.depromeet.linkzupzup.R
 import com.depromeet.linkzupzup.base.BaseView
-import com.depromeet.linkzupzup.extensions.mutableStateValue
-import com.depromeet.linkzupzup.extensions.noRippleClickable
-import com.depromeet.linkzupzup.extensions.timeBaseStr
-import com.depromeet.linkzupzup.extensions.timeStr
 import com.depromeet.linkzupzup.architecture.presenterLayer.AlarmDetailViewModel
 import com.depromeet.linkzupzup.architecture.presenterLayer.model.WeeklyAlarm
+import com.depromeet.linkzupzup.extensions.*
 import com.depromeet.linkzupzup.ui.theme.BottomSheetShape
 import com.depromeet.linkzupzup.ui.theme.LinkZupZupTheme
+import com.depromeet.linkzupzup.ui.theme.Round2RectShape
 import com.depromeet.linkzupzup.utils.DLog
 import com.depromeet.linkzupzup.view.custom.CustomSwitchCompat
 import com.depromeet.linkzupzup.view.custom.CustomTextCheckBox
@@ -47,6 +43,7 @@ import java.util.*
 
 class AlarmDetailUI: BaseView<AlarmDetailViewModel>() {
 
+    @ExperimentalFoundationApi
     @ExperimentalMaterialApi
     @ExperimentalPagerApi
     @Composable
@@ -70,9 +67,7 @@ fun AlarmDetailAppBar(appBarColor: MutableState<Color> = remember { mutableState
         navigationIcon = {
             Card(elevation = 0.dp,
                 backgroundColor = Color(0xFFF8FAFB),
-                modifier = Modifier.noRippleClickable {
-                    Toast.makeText(ctx, "뒤로가기", Toast.LENGTH_SHORT).show()
-                }) {
+                modifier = Modifier.noRippleClickable { toast(ctx, "뒤로가기") }) {
 
                 Column(verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.Start,
@@ -87,20 +82,20 @@ fun AlarmDetailAppBar(appBarColor: MutableState<Color> = remember { mutableState
         },
         backgroundColor = appBarColor.value,
         elevation = 0.dp,
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = Modifier.fillMaxWidth()
             .height(52.dp)
             .padding(start = 12.dp))
 }
 
+@ExperimentalFoundationApi
 @ExperimentalPagerApi
 @ExperimentalMaterialApi
 @Composable
 fun AlarmDetailBodyContent(alarms: ArrayList<WeeklyAlarm>) {
     val alarmList = remember { mutableStateOf(alarms) }
-
     val coroutineScope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
+
     ModalBottomSheetLayout(sheetState = sheetState,
         sheetShape = BottomSheetShape,
         sheetContent = { AlarmDetailModalBottomSheetContent(sheetState,coroutineScope) },
@@ -115,32 +110,28 @@ fun AlarmDetailBodyContent(alarms: ArrayList<WeeklyAlarm>) {
 
                 TopHeaderCard()
 
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(16.dp),
-                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                    modifier = Modifier.fillMaxWidth()
-                        .weight(1f)) {
+                if (alarmList.value.size > 0) {
+                    LazyColumn(verticalArrangement = Arrangement.spacedBy(16.dp),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                        modifier = Modifier.fillMaxWidth()
+                            .weight(1f)) {
 
-                    itemsIndexed(items= alarmList.value) { index, alarm ->
-                        WeeklyAlarmCard(alarmList, index)
+                        itemsIndexed(items= alarmList.value) { index, alarm ->
+                            WeeklyAlarmCard(alarmList, index)
+                        }
                     }
-                }
+                } else EmptyGuideCard(modifier = Modifier.fillMaxWidth()
+                    .weight(1f))
 
-                Column(modifier = Modifier
-                    .fillMaxWidth()
+                Column(modifier = Modifier.fillMaxWidth()
                     .height(68.dp)
                     .padding(start = 16.dp, top = 0.dp, end = 16.dp, bottom = 16.dp)) {
 
-                    Button(onClick = {
-                        DLog.e("Jackson", "click read button")
-                        coroutineScope.launch {
-                            sheetState.show()
-                        }
-                    },
+                    Button(onClick = { coroutineScope.launch { sheetState.show() } },
                         colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color(0xFF4076F6), contentColor = Color.White),
                         shape = RoundedCornerShape(4.dp),
                         elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth()
                             .height(52.dp)) {
 
                         Text("알림 추가하기",
@@ -156,73 +147,28 @@ fun AlarmDetailBodyContent(alarms: ArrayList<WeeklyAlarm>) {
     }
 }
 
-
-
-@ExperimentalMaterialApi
-@ExperimentalPagerApi
 @Composable
-fun BodyContent(alarms: ArrayList<WeeklyAlarm>) {
-    val alarmList = remember { mutableStateOf(alarms) }
+fun EmptyGuideCard(modifier: Modifier) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier.padding(bottom = 24.dp)
+            .background(Color.Transparent)) {
 
-    val coroutineScope = rememberCoroutineScope()
-    val bottomSheetScaffoldState = rememberBottomSheetScaffoldState(
-        bottomSheetState = BottomSheetState(BottomSheetValue.Collapsed)
-    )
+        // 도넛 이미지
+        Column(horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxWidth()
+                .weight(1f)) {
 
-    BottomSheetScaffold(
-        topBar = { AlarmDetailAppBar() },
-        scaffoldState = bottomSheetScaffoldState,
-        sheetContent = { AlarmDetailBottomSheet(bottomSheetScaffoldState,coroutineScope) },   // sheetContent -  Column scope
-        sheetShape = RoundedCornerShape(topStartPercent = 5,topEndPercent = 5),
-        sheetPeekHeight = 0.dp,
-        sheetBackgroundColor = Color(0xFFF8FAFB),
-        sheetGesturesEnabled = false,
-        backgroundColor = Color.Transparent,
-        modifier = Modifier.fillMaxSize()) {
-
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .fillMaxHeight()) {
-
-            TopHeaderCard()
-
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(16.dp),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)) {
-
-                itemsIndexed(items= alarmList.value) { index, alarm ->
-                    WeeklyAlarmCard(alarmList, index)
-                }
-            }
-
-            Column(modifier = Modifier
-                .fillMaxWidth()
-                .height(68.dp)
-                .padding(start = 16.dp, top = 0.dp, end = 16.dp, bottom = 16.dp)) {
-
-                Button(onClick = {
-                        DLog.e("Jackson", "click read button")
-                        coroutineScope.launch {
-                            bottomSheetScaffoldState.bottomSheetState.expand()
-                        }
-                    },
-                    colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color(0xFF4076F6), contentColor = Color.White),
-                    shape = RoundedCornerShape(4.dp),
-                    elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(52.dp)) {
-
-                    Text("알림 추가하기",
-                        style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_bold, weight = FontWeight.W700)), fontSize = 14.sp, lineHeight = 17.5.sp),
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth())
-
-                }
-            }
+            Image(painter = painterResource(id = R.drawable.ic_donut05),
+                contentDescription = null)
         }
+
+        Text("잊어버리지 않고 링크를 읽을 수 있도록\n원하는 시간에 알림을 받아보세요!\n\n\uD83D\uDC47\uD83D\uDC47\uD83D\uDC47 ",
+            style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_bold, weight = FontWeight.W400)), fontSize = 12.sp, lineHeight = 16.8.sp),
+            textAlign = TextAlign.Center,
+            color = Color(0xFF4076F6))
+
     }
 }
 
@@ -242,20 +188,25 @@ fun TopHeaderCard() {
     }
 }
 
+@ExperimentalFoundationApi
 @Composable
 fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
     list.value[index].let { alarm ->
 
+        val ctx = LocalContext.current
         // 알람 설정 유무
         val enableAlarm: MutableState<Boolean> = alarm.isEnableAlarm().mutableStateValue()
         alarm.enableAlarm = if (enableAlarm.value) 1 else 0
+        val switchCompat: MutableState<SwitchCompat?> = remember { mutableStateOf(null) }
 
         Card(shape = RoundedCornerShape(4.dp),
             backgroundColor = Color.White,
             elevation = 2.dp,
-            modifier = Modifier.clickable {
-
-            }) {
+            modifier = Modifier.combinedClickable(onClick = {
+                switchCompat.let { it.value?.isChecked = it.value?.isChecked?.not() ?: false }
+            }, onLongClick = {
+                toast(ctx, "Long Click")
+            })) {
 
             Box(Modifier.fillMaxWidth()
                 .height(110.dp)) {
@@ -263,6 +214,12 @@ fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
                 Column(modifier = Modifier.fillMaxWidth()
                     .height(110.dp)
                     .padding(horizontal = 24.dp, vertical = 19.dp)) {
+
+                    val textColor = Color(if (enableAlarm.value) 0xFF292A2B else 0xFFCED3D6)
+                    val weeksTagBgColor = Color(if (enableAlarm.value) 0xFFEAEBEF else 0xFFF8FAFB)
+                    val weeksTagTextColor = Color(if (enableAlarm.value) 0xFF000000 else 0xFFCED3D6)
+                    val holidayTagBgColor = Color(if (enableAlarm.value) 0xFFFFEFF0 else 0xFFF8FAFB)
+                    val holidayTagTextColor = Color(if (enableAlarm.value) 0xFFF24147 else 0xFFCED3D6)
 
                     Row(verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.fillMaxWidth()
@@ -274,15 +231,30 @@ fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
 
                         Spacer(Modifier.width(4.dp))
 
+                        // 오전 or 오후
                         Text(alarm.dateTime.timeBaseStr(),
-                            style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 12.sp, lineHeight = 16.8.sp, color = Color(0xFF292A2B)))
+                            style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 12.sp, lineHeight = 16.8.sp, color = textColor))
 
                         Spacer(Modifier.width(8.dp))
 
+                        // 알람 시간
                         Text(alarm.dateTime.timeStr(),
-                            style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), textAlign = TextAlign.Start, fontSize = 32.sp, lineHeight = 10.sp, color = Color(0xFF292A2B)),
+                            style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), textAlign = TextAlign.Start, fontSize = 32.sp, lineHeight = 10.sp, color = textColor),
                             modifier = Modifier.absoluteOffset(y = -(5).dp))
 
+                        Spacer(Modifier.weight(1f))
+
+                        Column(horizontalAlignment = Alignment.End,
+                                modifier = Modifier.fillMaxHeight()
+                                        .padding(top = 10.dp)) {
+
+                            CustomSwitchCompat(instanceCallback = {
+                                    switchCompat.value = it
+                                    it.isChecked = enableAlarm.value
+                                }, checkedOnChangeListener = { view, isChecked ->
+                                    enableAlarm.value = isChecked
+                                })
+                        }
                     }
 
                     Spacer(Modifier.height(10.dp))
@@ -291,13 +263,12 @@ fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
                         .height(22.dp)) {
 
                         Card(shape = RoundedCornerShape(2.dp),
-                            backgroundColor = Color(0xFFEAEBEF)) {
+                            backgroundColor = weeksTagBgColor) {
                             Box(contentAlignment = Alignment.Center) {
                                 Text(alarm.weekDayStr(),
-                                    style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 10.sp, lineHeight = 14.sp, color = Color(0xFF000000)),
+                                    style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 10.sp, lineHeight = 14.sp, color = weeksTagTextColor),
                                     textAlign = TextAlign.Center,
-                                    modifier = Modifier
-                                        .height(22.dp)
+                                    modifier = Modifier.height(22.dp)
                                         .padding(horizontal = 8.dp, vertical = 4.dp))
                             }
                         }
@@ -306,45 +277,21 @@ fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
 
                             Spacer(Modifier.width(8.dp))
 
-                            Card(shape = RoundedCornerShape(2.dp),
-                                backgroundColor = Color(0xFFFFEFF0)) {
+                            Card(shape = Round2RectShape,
+                                backgroundColor = holidayTagBgColor) {
                                 Box(contentAlignment = Alignment.Center) {
                                     Text("#공휴일에 울려요",
-                                        style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 10.sp, lineHeight = 14.sp, color = Color(0xFFF24147)),
+                                        style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_medium, weight = FontWeight.W400)), fontSize = 10.sp, lineHeight = 14.sp, color = holidayTagTextColor),
                                         textAlign = TextAlign.Center,
-                                        modifier = Modifier
-                                            .height(22.dp)
+                                        modifier = Modifier.height(22.dp)
                                             .padding(horizontal = 8.dp, vertical = 4.dp))
                                 }
                             }
                         }
                     }
                 }
-
-                /**
-                 * 비활성화 블러
-                 */
-                if (!enableAlarm.value) Row(Modifier.fillMaxWidth()
-                        .fillMaxHeight()
-                        .background(color = Color(0xCCFFFFFF))) {}
-
-                /**
-                 * 카드가 비활성화 될경우 블러 위에 스위치가 표현되어야 하므로 상위 레이어에 배치.
-                 */
-                Column(horizontalAlignment = Alignment.End,
-                    modifier = Modifier.fillMaxWidth()
-                        .height(110.dp)
-                        .padding(top = 29.dp, end = 24.dp)) {
-
-                    CustomSwitchCompat(instanceCallback = { it.isChecked = enableAlarm.value },
-                        checkedOnChangeListener = { view, isChecked ->
-                            enableAlarm.value = isChecked
-                        })
-                }
-
             }
         }
-
     }
 }
 
@@ -505,23 +452,21 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
 @ExperimentalMaterialApi
 @Composable
 fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, coroutineScope: CoroutineScope) {
-    Column(modifier = Modifier
-        .fillMaxWidth()
+    Column(modifier = Modifier.fillMaxWidth()
         .height(606.dp)
-        .background(Color.White)) {
+        .background(Color.White)
+        .noRippleClickable {  }) {
 
         val ctx = LocalContext.current
 
         // header, close btn
         Row(horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
                 .height(56.dp)) {
 
             Card(elevation = 0.dp,
-                modifier = Modifier
-                    .width(68.dp)
+                modifier = Modifier.width(68.dp)
                     .height(56.dp)
                     .noRippleClickable {
                         coroutineScope.launch {
@@ -531,8 +476,7 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
 
                 Row(verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.Center,
-                    modifier = Modifier
-                        .fillMaxSize()
+                    modifier = Modifier.fillMaxSize()
                         .padding(start = 20.dp, end = 16.dp)) {
 
                     Image(painter = painterResource(id = R.drawable.ic_black_close),
@@ -543,8 +487,7 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
         }
 
         // guide title
-        Row(modifier = Modifier
-            .fillMaxWidth()
+        Row(modifier = Modifier.fillMaxWidth()
             .padding(start = 24.dp, bottom = 28.dp)) {
 
             Text("언제마다\n알림을 받으시겠어요?",
@@ -554,11 +497,9 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
 
         // timepicker
         val timeDate = remember { mutableStateOf(Calendar.getInstance()) }
-        CustomTimePicker(modifier = Modifier
-            .fillMaxWidth()
+        CustomTimePicker(modifier = Modifier.fillMaxWidth()
             .height(210.dp)
             .padding(horizontal = 24.dp, vertical = 20.dp)) { type, timeVal ->
-
             when (type) {
                 Calendar.AM_PM -> timeDate.value.apply { set(Calendar.AM_PM, timeVal) }
                 Calendar.HOUR -> timeDate.value.apply { set(Calendar.HOUR, timeVal) }
@@ -567,9 +508,7 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
             }
         }
 
-        Column(
-            Modifier
-                .fillMaxWidth()
+        Column(Modifier.fillMaxWidth()
                 .height(96.dp)
                 .padding(horizontal = 24.dp, vertical = 20.dp)) {
 
@@ -581,8 +520,7 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
             Spacer(Modifier.height(12.dp))
 
             Row(verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
+                modifier = Modifier.fillMaxWidth()
                     .height(28.dp)) {
 
                 val toogleValues = arrayListOf("주중", "주말")
@@ -607,9 +545,7 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
 
         Spacer(Modifier.weight(1f))
 
-        Column(
-            Modifier
-                .fillMaxWidth()
+        Column(Modifier.fillMaxWidth()
                 .height(68.dp)
                 .padding(start = 24.dp, top = 0.dp, end = 16.dp, bottom = 24.dp)) {
 
@@ -617,16 +553,14 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
 
                 val isAlready = remember { mutableStateOf(false) }
                 if (isAlready.value) Row(
-                    Modifier
-                        .width(64.dp)
+                    Modifier.width(64.dp)
                         .fillMaxHeight()) {
 
                     Button(colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color.White, contentColor = Color(0xFF4076F6)),
                         shape = RoundedCornerShape(4.dp),
                         elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
                         border = BorderStroke(width = 1.dp, Color(0xFF4076F6)),
-                        modifier = Modifier
-                            .fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth()
                             .height(52.dp)
                             .padding(end = 12.dp),
                         onClick = {
@@ -648,8 +582,7 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
                 Button(colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color(0xFF4076F6), contentColor = Color.White),
                     shape = RoundedCornerShape(4.dp),
                     elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
-                    modifier = Modifier
-                        .weight(1f)
+                    modifier = Modifier.weight(1f)
                         .height(52.dp),
                     onClick = {
                         DLog.e("Jackson", "save click read button")
@@ -671,6 +604,7 @@ fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, 
     }
 }
 
+@ExperimentalFoundationApi
 @ExperimentalMaterialApi
 @ExperimentalPagerApi
 @Preview
@@ -685,7 +619,7 @@ fun previewSample() {
 
     LinkZupZupTheme {
         Surface(color = MaterialTheme.colors.background) {
-            BodyContent(listDatas)
+            AlarmDetailBodyContent(listDatas)
         }
     }
 }

--- a/app/src/main/java/com/depromeet/linkzupzup/view/alarm/ui/AlarmDetailUI.kt
+++ b/app/src/main/java/com/depromeet/linkzupzup/view/alarm/ui/AlarmDetailUI.kt
@@ -33,6 +33,7 @@ import com.depromeet.linkzupzup.extensions.timeBaseStr
 import com.depromeet.linkzupzup.extensions.timeStr
 import com.depromeet.linkzupzup.presenter.AlarmDetailViewModel
 import com.depromeet.linkzupzup.presenter.model.WeeklyAlarm
+import com.depromeet.linkzupzup.ui.theme.BottomSheetShape
 import com.depromeet.linkzupzup.ui.theme.LinkZupZupTheme
 import com.depromeet.linkzupzup.utils.DLog
 import com.depromeet.linkzupzup.view.custom.CustomSwitchCompat
@@ -53,7 +54,8 @@ class AlarmDetailUI: BaseView<AlarmDetailViewModel>() {
         LinkZupZupTheme {
             Surface(color = Color(0xFFF8FAFB)) {
                 vm?.getWeeklyAlarmList()?.let { alarmList ->
-                    BodyContent(alarmList)
+                    // BodyContent(alarmList)
+                    AlarmDetailBodyContent(alarmList)
                 }
             }
         }
@@ -90,6 +92,70 @@ fun AlarmDetailAppBar(appBarColor: MutableState<Color> = remember { mutableState
             .height(52.dp)
             .padding(start = 12.dp))
 }
+
+@ExperimentalPagerApi
+@ExperimentalMaterialApi
+@Composable
+fun AlarmDetailBodyContent(alarms: ArrayList<WeeklyAlarm>) {
+    val alarmList = remember { mutableStateOf(alarms) }
+
+    val coroutineScope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
+    ModalBottomSheetLayout(sheetState = sheetState,
+        sheetShape = BottomSheetShape,
+        sheetContent = { AlarmDetailModalBottomSheetContent(sheetState,coroutineScope) },
+        modifier = Modifier.fillMaxSize()) {
+
+        Scaffold(topBar = { AlarmDetailAppBar() },
+            backgroundColor = Color.Transparent,
+            modifier = Modifier.fillMaxSize()) {
+
+            Column(modifier = Modifier.fillMaxWidth()
+                .fillMaxHeight()) {
+
+                TopHeaderCard()
+
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(16.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                        .weight(1f)) {
+
+                    itemsIndexed(items= alarmList.value) { index, alarm ->
+                        WeeklyAlarmCard(alarmList, index)
+                    }
+                }
+
+                Column(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(68.dp)
+                    .padding(start = 16.dp, top = 0.dp, end = 16.dp, bottom = 16.dp)) {
+
+                    Button(onClick = {
+                        DLog.e("Jackson", "click read button")
+                        coroutineScope.launch {
+                            sheetState.show()
+                        }
+                    },
+                        colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color(0xFF4076F6), contentColor = Color.White),
+                        shape = RoundedCornerShape(4.dp),
+                        elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)) {
+
+                        Text("알림 추가하기",
+                            style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_bold, weight = FontWeight.W700)), fontSize = 14.sp, lineHeight = 17.5.sp),
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth())
+
+                    }
+                }
+            }
+
+        }
+    }
+}
+
 
 
 @ExperimentalMaterialApi
@@ -191,15 +257,19 @@ fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
 
             }) {
 
-            Box(Modifier.fillMaxWidth()
-                .height(110.dp)) {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(110.dp)) {
 
-                Column(modifier = Modifier.fillMaxWidth()
+                Column(modifier = Modifier
+                    .fillMaxWidth()
                     .height(110.dp)
                     .padding(horizontal = 24.dp, vertical = 19.dp)) {
 
                     Row(verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
                             .height(40.dp)) {
 
                         Image(painter = painterResource(id = R.drawable.ic_sun_img),
@@ -221,7 +291,8 @@ fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
 
                     Spacer(Modifier.height(10.dp))
 
-                    Row(modifier = Modifier.fillMaxWidth()
+                    Row(modifier = Modifier
+                        .fillMaxWidth()
                         .height(22.dp)) {
 
                         Card(shape = RoundedCornerShape(2.dp),
@@ -258,7 +329,9 @@ fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
                 /**
                  * 비활성화 블러
                  */
-                if (!enableAlarm.value) Row(Modifier.fillMaxWidth()
+                if (!enableAlarm.value) Row(
+                    Modifier
+                        .fillMaxWidth()
                         .fillMaxHeight()
                         .background(color = Color(0xCCFFFFFF))) {}
 
@@ -266,7 +339,8 @@ fun WeeklyAlarmCard(list: MutableState<ArrayList<WeeklyAlarm>>, index: Int) {
                  * 카드가 비활성화 될경우 블러 위에 스위치가 표현되어야 하므로 상위 레이어에 배치.
                  */
                 Column(horizontalAlignment = Alignment.End,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
                         .height(110.dp)
                         .padding(top = 29.dp, end = 24.dp)) {
 
@@ -296,11 +370,13 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
         // header, close btn
         Row(horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .height(56.dp)) {
 
             Card(elevation = 0.dp,
-                modifier = Modifier.width(68.dp)
+                modifier = Modifier
+                    .width(68.dp)
                     .height(56.dp)
                     .noRippleClickable {
                         coroutineScope.launch {
@@ -310,7 +386,8 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
 
                 Row(verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.Center,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .fillMaxSize()
                         .padding(start = 20.dp, end = 16.dp)) {
 
                     Image(painter = painterResource(id = R.drawable.ic_black_close),
@@ -321,7 +398,8 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
         }
 
         // guide title
-        Row(modifier = Modifier.fillMaxWidth()
+        Row(modifier = Modifier
+            .fillMaxWidth()
             .padding(start = 24.dp, bottom = 28.dp)) {
 
             Text("언제마다\n알림을 받으시겠어요?",
@@ -331,7 +409,8 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
 
         // timepicker
         val timeDate = remember { mutableStateOf(Calendar.getInstance()) }
-        CustomTimePicker(modifier = Modifier.fillMaxWidth()
+        CustomTimePicker(modifier = Modifier
+            .fillMaxWidth()
             .height(210.dp)
             .padding(horizontal = 24.dp, vertical = 20.dp)) { type, timeVal ->
 
@@ -343,9 +422,11 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
             }
         }
 
-        Column(Modifier.fillMaxWidth()
-            .height(96.dp)
-            .padding(horizontal = 24.dp, vertical = 20.dp)) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .height(96.dp)
+                .padding(horizontal = 24.dp, vertical = 20.dp)) {
 
             Text("반복 설정",
                 color = Color(0xFF292A2B),
@@ -355,7 +436,8 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
             Spacer(Modifier.height(12.dp))
 
             Row(verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
                     .height(28.dp)) {
 
                 val toogleValues = arrayListOf("주중", "주말")
@@ -380,21 +462,28 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
 
         Spacer(Modifier.weight(1f))
 
-        Column(Modifier.fillMaxWidth()
-            .height(68.dp)
-            .padding(start = 24.dp, top = 0.dp, end = 16.dp, bottom = 24.dp)) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .height(68.dp)
+                .padding(start = 24.dp, top = 0.dp, end = 16.dp, bottom = 24.dp)) {
 
             Row(Modifier.fillMaxSize()) {
 
                 val isAlready = remember { mutableStateOf(false) }
-                if (isAlready.value) Row(Modifier.width(64.dp)
-                    .fillMaxHeight()) {
+                if (isAlready.value) Row(
+                    Modifier
+                        .width(64.dp)
+                        .fillMaxHeight()) {
 
                     Button(colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color.White, contentColor = Color(0xFF4076F6)),
                         shape = RoundedCornerShape(4.dp),
                         elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
                         border = BorderStroke(width = 1.dp, Color(0xFF4076F6)),
-                        modifier = Modifier.fillMaxWidth().height(52.dp).padding(end = 12.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
+                            .padding(end = 12.dp),
                         onClick = {
                             DLog.e("Jackson", "save click read button")
                             coroutineScope.launch {
@@ -414,12 +503,184 @@ fun AlarmDetailBottomSheet(bottomSheetScaffoldState: BottomSheetScaffoldState, c
                 Button(colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color(0xFF4076F6), contentColor = Color.White),
                     shape = RoundedCornerShape(4.dp),
                     elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
-                    modifier = Modifier.weight(1f).height(52.dp),
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(52.dp),
                     onClick = {
                         DLog.e("Jackson", "save click read button")
                         coroutineScope.launch {
                             Toast.makeText(ctx, "저장하기", Toast.LENGTH_SHORT).show()
                             bottomSheetScaffoldState.bottomSheetState.collapse()
+                        }
+                    }) {
+
+                    Text("저장하기",
+                        style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_bold, weight = FontWeight.W700)), fontSize = 14.sp, lineHeight = 17.5.sp),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth())
+
+                }
+            }
+        }
+
+    }
+}
+
+@ExperimentalPagerApi
+@ExperimentalMaterialApi
+@Composable
+fun AlarmDetailModalBottomSheetContent(bottomSheetState: ModalBottomSheetState, coroutineScope: CoroutineScope) {
+    Column(modifier = Modifier
+        .fillMaxWidth()
+        .height(606.dp)
+        .background(Color.White)) {
+
+        val ctx = LocalContext.current
+
+        // header, close btn
+        Row(horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)) {
+
+            Card(elevation = 0.dp,
+                modifier = Modifier
+                    .width(68.dp)
+                    .height(56.dp)
+                    .noRippleClickable {
+                        coroutineScope.launch {
+                            bottomSheetState.hide()
+                        }
+                    }) {
+
+                Row(verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(start = 20.dp, end = 16.dp)) {
+
+                    Image(painter = painterResource(id = R.drawable.ic_black_close),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp))
+                }
+            }
+        }
+
+        // guide title
+        Row(modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 24.dp, bottom = 28.dp)) {
+
+            Text("언제마다\n알림을 받으시겠어요?",
+                color = Color(0xFF292A2B),
+                style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_bold, weight = FontWeight.W700)), fontSize = 24.sp, lineHeight = 32.4.sp, color = Color(0xFF292A2B)))
+        }
+
+        // timepicker
+        val timeDate = remember { mutableStateOf(Calendar.getInstance()) }
+        CustomTimePicker(modifier = Modifier
+            .fillMaxWidth()
+            .height(210.dp)
+            .padding(horizontal = 24.dp, vertical = 20.dp)) { type, timeVal ->
+
+            when (type) {
+                Calendar.AM_PM -> timeDate.value.apply { set(Calendar.AM_PM, timeVal) }
+                Calendar.HOUR -> timeDate.value.apply { set(Calendar.HOUR, timeVal) }
+                Calendar.MINUTE -> timeDate.value.apply { set(Calendar.MINUTE, timeVal) }
+                else -> timeDate.value
+            }
+        }
+
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .height(96.dp)
+                .padding(horizontal = 24.dp, vertical = 20.dp)) {
+
+            Text("반복 설정",
+                color = Color(0xFF292A2B),
+                style = TextStyle(fontFamily = FontFamily(Font(resId = R.font.spoqa_hansansneo_bold, weight = FontWeight.W700)), fontSize = 12.sp, lineHeight = 16.8.sp, color = Color(0xFF292A2B)),
+                modifier = Modifier.height(16.dp))
+
+            Spacer(Modifier.height(12.dp))
+
+            Row(verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(28.dp)) {
+
+                val toogleValues = arrayListOf("주중", "주말")
+                CustomToogle(modifier = Modifier.height(28.dp), datas = toogleValues, onChangeListener = {
+                    DLog.e("TEST", toogleValues[it])
+                })
+
+                Spacer(Modifier.weight(1f))
+
+                CustomTextCheckBox(modifier = Modifier.height(20.dp),
+                    text = "공휴일엔 알람 끄기",
+                    enableImg = R.drawable.ic_holiday_on,
+                    disableImg = R.drawable.ic_holiday_off,
+                    enableColor = Color(0xFF4076F6),
+                    disableColor = Color(0xFF878D91),
+                    onChangeListener = {
+                        DLog.e("TEST", if (it) "공휴일 알람 비활성" else "공휴일 알람 활성")
+                    })
+
+            }
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .height(68.dp)
+                .padding(start = 24.dp, top = 0.dp, end = 16.dp, bottom = 24.dp)) {
+
+            Row(Modifier.fillMaxSize()) {
+
+                val isAlready = remember { mutableStateOf(false) }
+                if (isAlready.value) Row(
+                    Modifier
+                        .width(64.dp)
+                        .fillMaxHeight()) {
+
+                    Button(colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color.White, contentColor = Color(0xFF4076F6)),
+                        shape = RoundedCornerShape(4.dp),
+                        elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
+                        border = BorderStroke(width = 1.dp, Color(0xFF4076F6)),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
+                            .padding(end = 12.dp),
+                        onClick = {
+                            DLog.e("Jackson", "save click read button")
+                            coroutineScope.launch {
+                                Toast.makeText(ctx, "삭제", Toast.LENGTH_SHORT).show()
+                                bottomSheetState.hide()
+                            }
+                        }) {
+
+                        Image(painter = painterResource(id = R.drawable.ic_blue_trash),
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp))
+
+                    }
+
+                }
+
+                Button(colors = ButtonDefaults.outlinedButtonColors(backgroundColor = Color(0xFF4076F6), contentColor = Color.White),
+                    shape = RoundedCornerShape(4.dp),
+                    elevation = elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(52.dp),
+                    onClick = {
+                        DLog.e("Jackson", "save click read button")
+                        coroutineScope.launch {
+                            Toast.makeText(ctx, "저장하기", Toast.LENGTH_SHORT).show()
+                            bottomSheetState.hide()
                         }
                     }) {
 


### PR DESCRIPTION
알람 상세화면 링크 없을때 #19
알람 상세화면 BottomSheet 적용 #9

- 추후 Interceptor에서 status 를 참조하기 위해
DefaultResponseEntity 를 생성하였습니다.
- ResponseEntity 외 ResponseArrayEntity 추가
- 알람 리스트 API 테스트 완료
- 알람 상세화면 리스트 데이터 없을 경우 가이드 노출 적용
- SwitchComapt 클릭영역 알람 카드 전체로 변경
- 알람 카드 롱클릭 리스너 추가 ( 알람 수정 )